### PR TITLE
Replace concept-dist with concept-sim

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -218,24 +218,35 @@ src/
 - `--model` — 埋め込みモデル（デフォルト: `text-embedding-3-small`、環境変数 `CONCEPT_EMBED_MODEL`）
 - `--api-base` — OpenAI互換APIのベースURL（環境変数 `CONCEPT_API_BASE`）
 
-### concept-dist
+### concept-sim
 
-クエリの `.concept` ファイルから1つ以上のターゲットへのコサイン距離を計算します。結果は距離の近い順にソートされます。
+クエリの `.concept` ファイルから1つ以上のターゲットへのコサイン類似度を計算します。結果は類似度の高い順にソートされます。
 
 ```bash
-cli/concept-dist query.concept targets/*.concept
+cli/concept-sim query.concept targets/*.concept
 ```
 
 ```
-0.0000  User                 concepts/User.concept
-0.2463  Order                concepts/Order.concept
-0.3400  AuthService          concepts/AuthService.concept
-0.3955  Product              concepts/Product.concept
-0.4739  PaymentService       concepts/PaymentService.concept
-0.5815  ProductSearchService concepts/ProductSearchService.concept
+1.000  User                 concepts/User.concept
+0.754  Order                concepts/Order.concept
+0.660  AuthService          concepts/AuthService.concept
+0.605  Product              concepts/Product.concept
+0.526  PaymentService       concepts/PaymentService.concept
+0.419  ProductSearchService concepts/ProductSearchService.concept
 ```
 
-距離 0 = 同一、1 = 完全に無関係。
+`-s` オプションでスコアとしきい値を表示できます：
+
+```bash
+cli/concept-sim -s --threshold 0.5 query.concept targets/*.concept
+```
+
+```
+1.000 (>0.50)  User                 concepts/User.concept
+0.754 (>0.50)  Order                concepts/Order.concept
+```
+
+類似度 1.0 = 同一、0.0 = 完全に無関係。
 
 ### concept-plot
 
@@ -300,7 +311,7 @@ done
 「`User` に最も似ているクラスはどれ？」
 
 ```bash
-cli/concept-dist examples/java-project/concepts/User.concept examples/java-project/concepts/*.concept
+cli/concept-sim examples/java-project/concepts/User.concept examples/java-project/concepts/*.concept
 ```
 
 結果は `Order`（購入関係）と `AuthService`（認証関係）が `User` に最も近いことを示しており、コード上の実際のドメイン関係と一致しています。
@@ -445,7 +456,7 @@ concept-file/
 │   ├── concept-search       — .concept ファイルのセマンティック検索
 │   ├── concept-grep         — ソースファイルのセマンティック grep
 │   ├── concept-show         — 人間が読める形式で表示
-│   ├── concept-dist         — 距離計算
+│   ├── concept-sim          — 類似度計算
 │   └── concept-plot         — UMAP 2D/3D 散布図で可視化
 └── examples/
     ├── java-project/

--- a/README.md
+++ b/README.md
@@ -220,24 +220,35 @@ Options:
 - `--model` — Embedding model (default: `text-embedding-3-small`, env: `CONCEPT_EMBED_MODEL`)
 - `--api-base` — OpenAI-compatible API base URL (env: `CONCEPT_API_BASE`)
 
-### concept-dist
+### concept-sim
 
-Calculate cosine distance from a query `.concept` file to one or more targets. Results are sorted by distance (closest first).
+Calculate cosine similarity from a query `.concept` file to one or more targets. Results are sorted by similarity (most similar first).
 
 ```bash
-cli/concept-dist query.concept targets/*.concept
+cli/concept-sim query.concept targets/*.concept
 ```
 
 ```
-0.0000  User                 concepts/User.concept
-0.2463  Order                concepts/Order.concept
-0.3400  AuthService          concepts/AuthService.concept
-0.3955  Product              concepts/Product.concept
-0.4739  PaymentService       concepts/PaymentService.concept
-0.5815  ProductSearchService concepts/ProductSearchService.concept
+1.000  User                 concepts/User.concept
+0.754  Order                concepts/Order.concept
+0.660  AuthService          concepts/AuthService.concept
+0.605  Product              concepts/Product.concept
+0.526  PaymentService       concepts/PaymentService.concept
+0.419  ProductSearchService concepts/ProductSearchService.concept
 ```
 
-Distance 0 = identical, 1 = completely unrelated.
+Use `-s` to show scores with threshold:
+
+```bash
+cli/concept-sim -s --threshold 0.5 query.concept targets/*.concept
+```
+
+```
+1.000 (>0.50)  User                 concepts/User.concept
+0.754 (>0.50)  Order                concepts/Order.concept
+```
+
+Similarity 1.0 = identical, 0.0 = completely unrelated.
 
 ### concept-plot
 
@@ -424,7 +435,7 @@ concept-file/
 │   ├── concept-search       — Semantic search over .concept files
 │   ├── concept-grep         — Semantic grep over source files
 │   ├── concept-show         — Human-readable display
-│   ├── concept-dist         — Distance calculation
+│   ├── concept-sim          — Similarity calculation
 │   └── concept-plot         — UMAP 2D/3D scatter plot visualization
 └── examples/
     ├── java-project/

--- a/cli/concept-sim
+++ b/cli/concept-sim
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Calculate cosine distance between .concept files."""
+"""Calculate cosine similarity between .concept files."""
 
 import argparse
 import sys
@@ -8,15 +8,19 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "python"))
 
 from concept_file import read_concept
-from concept_file.search import cosine_distance
+from concept_file.search import cosine_similarity
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Calculate cosine distance from a query .concept file to target files"
+        description="Calculate cosine similarity from a query .concept file to target files"
     )
     parser.add_argument("query", help="Query .concept file")
     parser.add_argument("targets", nargs="+", help="Target .concept file(s)")
+    parser.add_argument("-s", "--score", action="store_true",
+                        help="Show similarity scores")
+    parser.add_argument("--threshold", type=float, default=0.5,
+                        help="Minimum similarity score (default: 0.5)")
     args = parser.parse_args()
 
     try:
@@ -38,15 +42,18 @@ def main():
             if not target_vec:
                 print(f"Warning: {target_path} has no embedding, skipping", file=sys.stderr)
                 continue
-            dist = cosine_distance(query_vec, target_vec)
-            results.append((dist, target_path, target_data.get("concept", "")))
+            sim = cosine_similarity(query_vec, target_vec)
+            results.append((sim, target_path, target_data.get("concept", "")))
         except (ValueError, FileNotFoundError) as e:
             print(f"Warning: {target_path}: {e}", file=sys.stderr)
 
-    results.sort(key=lambda x: x[0])
+    results.sort(key=lambda x: x[0], reverse=True)
 
-    for dist, path, name in results:
-        print(f"{dist:.4f}\t{name}\t{path}")
+    for sim, path, name in results:
+        if args.score:
+            print(f"{sim:.3f} (>{args.threshold:.2f})\t{name}\t{path}")
+        else:
+            print(f"{sim:.3f}\t{name}\t{path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Rename `concept-dist` to `concept-sim`
- Change output from cosine distance to cosine similarity (match rate), sorted highest first
- Add `-s`/`--score` option to show scores with threshold, consistent with `concept-grep`
- Update `README.md` and `README.ja.md`

Closes #9

## Test plan

- [x] `cli/concept-sim query.concept targets/*.concept` outputs similarity scores in descending order
- [x] `cli/concept-sim -s --threshold 0.5 query.concept targets/*.concept` shows `score (>threshold)` format matching `concept-grep -s`
- [x] `concept-dist` is removed