### PR TITLE
Reverse output order of concept-grep -v

### DIFF
--- a/cli/concept-grep
+++ b/cli/concept-grep
@@ -223,7 +223,7 @@ def main():
             print(f"Warning: {concept_path}: {e}", file=sys.stderr)
 
     matched.sort(key=lambda x: x[0], reverse=True)
-    unmatched.sort(key=lambda x: x[0], reverse=True)
+    unmatched.sort(key=lambda x: x[0])
 
     # Select results based on -v flag
     results = unmatched if args.invert_match else matched


### PR DESCRIPTION
## Summary

- Sort `-v` (invert match) results in ascending order (lowest similarity first)
- Previously both matched and unmatched were sorted descending; with `-v` the reversed order makes the results easier to read, with files closest to the threshold appearing at the bottom

Closes #10

## Test plan

- [x] `concept-grep -v -s "query" *` outputs results with lowest similarity scores first
- [x] Files closest to the threshold appear at the bottom of the output