### PR TITLE
Add bar graph display for concept-grep -s option

### DIFF
--- a/cli/concept-grep
+++ b/cli/concept-grep
@@ -233,10 +233,19 @@ def main():
     if args.top > 0:
         results = results[: args.top]
 
+    if args.graph and results:
+        sims = [s for s, _ in results]
+        min_sim, max_sim = min(sims), max(sims)
+        sim_range = max_sim - min_sim
+
     for sim, sf in results:
         op = "<" if args.invert_match else ">"
         if args.graph:
-            bar = "█" * max(1, int(sim * 10))
+            if sim_range == 0:
+                bar_width = 10
+            else:
+                bar_width = max(1, round((sim - min_sim) / sim_range * 10))
+            bar = "█" * bar_width
             print(f"{bar:<10}({op}{args.threshold:.2f})\t{sf}")
         elif args.score:
             print(f"{sim:.3f} ({op}{args.threshold:.2f})\t{sf}")


### PR DESCRIPTION
## Summary

- Add `-g`/`--graph` option to display similarity as a `█` character bar graph
- Keep `-s`/`--score` option as numeric score display (unchanged)
- Bar width is normalized based on the min-max range of the result set (0–10 scale)

## Output format

| Option | Example output |
|--------|---------------|
| (none) | `coding-agent-4.md` |
| `-s` | `0.734 (>0.50)	coding-agent-4.md` |
| `-g` | `██████████(>0.50)	coding-agent-4.md` |

```
$ concept-grep -g agent *
██████████(>0.50)	coding-agent-4.md
███████   (>0.50)	coding-agent-3.md
████      (>0.50)	coding-agent-6.md
██        (>0.50)	coding-agent-5.md
█         (>0.50)	coding-agent-1.md
```

Closes #11

## Test plan

- [x] `concept-grep -g "query" *` outputs bar graph with `█` characters
- [x] Highest-scoring result always shows 10 blocks, lowest shows 1
- [x] `concept-grep -s "query" *` still outputs numeric scores (unchanged)