### PR TITLE
Change concept-grep filtering from threshold to top percentage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -197,7 +197,10 @@ concept-grep -r "決済処理" src/
 # スコア表示
 concept-grep -s "サーバーへのデータ送信" src/*.java
 
-# 逆マッチ: 閾値以下のファイルを表示
+# 上位20%を表示
+concept-grep -p 20 -r "データバリデーション" src/
+
+# 逆マッチ: 類似度が低いファイルを表示
 concept-grep -v "サーバーへのデータ送信" src/*.java
 
 # パイプと組み合わせ
@@ -231,9 +234,9 @@ src/
 - `-r, --recursive` — ディレクトリを再帰的に検索（`.git/`, `.concept/`, `.venv/`, `node_modules/` はスキップ）
 - `-s, --score` — 類似度スコアを表示
 - `-g, --graph` — 類似度をバーグラフで表示
-- `-v, --invert-match` — 閾値以下のファイルを表示（逆マッチ、`grep -v` と同様）
+- `-v, --invert-match` — 類似度が低いファイルを表示（逆マッチ、`grep -v` と同様）
 - `-n, --top` — 上位N件のみ表示（デフォルト: 全件）
-- `--threshold` — 最低類似度スコア（デフォルト: 0.5）
+- `-p, --top-percent` — 上位N%を表示（デフォルト: 10）
 - `--index` — 指定したソースファイルの `.concept` ファイルを生成（対応言語では tree-sitter による要約を使用）
 - `--model` — 埋め込みモデル（デフォルト: `text-embedding-3-small`、環境変数 `CONCEPT_EMBED_MODEL`）
 - `--api-base` — OpenAI互換APIのベースURL（環境変数 `CONCEPT_API_BASE`）

--- a/README.md
+++ b/README.md
@@ -199,7 +199,10 @@ concept-grep -r "payment processing" src/
 # Show scores
 concept-grep -s "data transmission to the server" src/*.java
 
-# Invert match: show files below threshold
+# Show top 20% of results
+concept-grep -p 20 -r "data validation" src/
+
+# Invert match: show least similar files
 concept-grep -v "data transmission to the server" src/*.java
 
 # Pipe-friendly
@@ -233,9 +236,9 @@ Options:
 - `-r, --recursive` — Recurse into directories (skips `.git/`, `.concept/`, `.venv/`, `node_modules/`)
 - `-s, --score` — Show similarity scores
 - `-g, --graph` — Show similarity as a bar graph
-- `-v, --invert-match` — Show files below threshold (invert match, like `grep -v`)
+- `-v, --invert-match` — Show least similar files (invert match, like `grep -v`)
 - `-n, --top` — Show only top N results (default: all)
-- `--threshold` — Minimum similarity score (default: 0.5)
+- `-p, --top-percent` — Show top N% of results by similarity (default: 10)
 - `--index` — Generate `.concept` files for the specified source files (uses tree-sitter summarization for supported languages)
 - `--model` — Embedding model (default: `text-embedding-3-small`, env: `CONCEPT_EMBED_MODEL`)
 - `--api-base` — OpenAI-compatible API base URL (env: `CONCEPT_API_BASE`)

--- a/cli/concept-grep
+++ b/cli/concept-grep
@@ -115,11 +115,11 @@ def main():
     parser.add_argument("-g", "--graph", action="store_true",
                         help="Show similarity as a bar graph")
     parser.add_argument("-v", "--invert-match", action="store_true",
-                        help="Show files below threshold (invert match)")
+                        help="Show least similar files (invert match)")
     parser.add_argument("-n", "--top", type=int, default=0,
                         help="Show only top N results (default: all)")
-    parser.add_argument("--threshold", type=float, default=0.5,
-                        help="Minimum similarity score (default: 0.5)")
+    parser.add_argument("-p", "--top-percent", type=float, default=10,
+                        help="Show top N%% of results by similarity (default: 10)")
     parser.add_argument("--model",
                         default=os.environ.get("CONCEPT_EMBED_MODEL", "text-embedding-3-small"),
                         help="Embedding model (env: CONCEPT_EMBED_MODEL)")
@@ -209,8 +209,9 @@ def main():
         print(f"Error generating query embedding: {e}", file=sys.stderr)
         sys.exit(1)
 
-    matched = []
-    unmatched = []
+    import math
+
+    all_results = []
     for sf in source_files:
         concept_path = source_to_concept_path(concept_root, sf)
         if not concept_path or not concept_path.exists():
@@ -226,21 +227,22 @@ def main():
             if not target_vec:
                 continue
             sim = cosine_similarity(query_vec, target_vec)
-            if sim >= args.threshold:
-                matched.append((sim, sf))
-            else:
-                unmatched.append((sim, sf))
+            all_results.append((sim, sf))
         except (ValueError, FileNotFoundError) as e:
             print(f"Warning: {concept_path}: {e}", file=sys.stderr)
 
-    matched.sort(key=lambda x: x[0], reverse=True)
-    unmatched.sort(key=lambda x: x[0])
+    # Sort by similarity: descending for normal, ascending for invert
+    if args.invert_match:
+        all_results.sort(key=lambda x: x[0])
+    else:
+        all_results.sort(key=lambda x: x[0], reverse=True)
 
-    # Select results based on -v flag
-    results = unmatched if args.invert_match else matched
-
+    # Apply top N or top percentage
     if args.top > 0:
-        results = results[: args.top]
+        results = all_results[: args.top]
+    else:
+        count = max(1, math.ceil(len(all_results) * args.top_percent / 100))
+        results = all_results[: count]
 
     if args.graph and results:
         sims = [s for s, _ in results]
@@ -248,16 +250,15 @@ def main():
         sim_range = max_sim - min_sim
 
     for sim, sf in results:
-        op = "<" if args.invert_match else ">"
         if args.graph:
             if sim_range == 0:
                 bar_width = 10
             else:
                 bar_width = max(1, round((sim - min_sim) / sim_range * 10))
             bar = "█" * bar_width
-            print(f"{bar:<10}({op}{args.threshold:.2f})\t{sf}")
+            print(f"{bar:<10}({sim:.2f})\t{sf}")
         elif args.score:
-            print(f"{sim:.3f} ({op}{args.threshold:.2f})\t{sf}")
+            print(f"{sim:.3f}\t{sf}")
         else:
             print(sf)
 


### PR DESCRIPTION
## Summary

- Replace `--threshold` (fixed similarity cutoff, default 0.5) with `-p/--top-percent` (show top N% of results, default 10%)
- A percentage-based approach automatically adapts to different embedding models and corpus sizes
- `-n/--top` (top N results) still works and takes priority over `-p`

## Examples

```bash
# Default: show top 10% of results
concept-grep -r "user authentication" src/

# Show top 20%
concept-grep -p 20 -r "payment processing" src/

# Top 3 results (overrides -p)
concept-grep -n 3 -r "cache" src/

# Invert: show least similar 10%
concept-grep -v -r "error handling" src/
```

Closes #21

## Test plan

- [x] Default top 10% returns correct number of results (52 files → 6 results)
- [x] `-p 20` returns ~11 results
- [x] `-n 3` overrides percentage and returns exactly 3
- [x] `-v` invert match shows least similar files
- [x] `-s` and `-g` display modes work correctly
- [x] Score display no longer shows threshold, shows actual similarity