### PR TITLE
Set embed_source to null when tree-sitter fallback is used

### DIFF
--- a/cli/concept-embed
+++ b/cli/concept-embed
@@ -69,8 +69,11 @@ def main():
     if args.source_file:
         from concept_file.summarizer import summarize
         source_text = Path(args.source_file).read_text(encoding="utf-8")
-        embed_source, _ = summarize(args.source_file, source_text)
-        data["embed_source"] = embed_source
+        embed_source, used_summarizer = summarize(args.source_file, source_text)
+        if used_summarizer:
+            data["embed_source"] = embed_source
+        else:
+            data["embed_source"] = None
 
     if not args.no_embed:
         embed_text = embed_source if embed_source else text

--- a/cli/concept-grep
+++ b/cli/concept-grep
@@ -213,14 +213,14 @@ def main():
                 if not text.strip():
                     continue
                 from concept_file.summarizer import summarize
-                embed_source, _ = summarize(str(sf), text)
+                embed_source, used_summarizer = summarize(str(sf), text)
                 vector = embed_query(embed_source, args.model, api_base=args.api_base)
                 data = {
                     "concept": sf.name,
                     "version": "1.0",
                     "created_at": datetime.now(timezone.utc).isoformat(),
                     "text": text,
-                    "embed_source": embed_source,
+                    "embed_source": embed_source if used_summarizer else None,
                     "embedding": {
                         "model": args.model,
                         "dim": len(vector),

--- a/cli/concept-show
+++ b/cli/concept-show
@@ -123,7 +123,10 @@ def main():
             print(f"  {rel['type']:>10} -> {rel['ref']}")
 
     embed_source = data.get("embed_source")
-    if embed_source:
+    if "embed_source" in data:
+        if embed_source is None:
+            # Reconstruct from concept name + text
+            embed_source = data.get("concept", "") + "\n" + data.get("text", "")
         print()
         print("--- Embed Source ---")
         print(embed_source)

--- a/tests/test_concept_embed.py
+++ b/tests/test_concept_embed.py
@@ -249,8 +249,9 @@ class TestTreeSitterIntegration:
         )
         assert result.returncode == 0
         data, _ = read_concept_file(out)
-        # Fallback: embed_source should contain the filename and text
+        # Fallback: embed_source should be null
         assert "embed_source" in data
+        assert data["embed_source"] is None
 
     def test_text_preserved_with_source_file(self, tmp_path):
         src = tmp_path / "calc.py"


### PR DESCRIPTION
## Summary

When tree-sitter summarization is not applied (unsupported file types like markdown), `embed_source` was storing `"filename\n" + text` — nearly identical to `text`. This wastes space.

Now:
- **tree-sitter succeeds** → `embed_source` stores the compact summary (as before)
- **tree-sitter fallback** → `embed_source` is set to `null`
- **concept-show** reconstructs `embed_source` from `concept` + `text` when it is `null`

## Example

Before (markdown file):
```json
"text": "# Hello World\n...",
"embed_source": "test.md\n# Hello World\n..."
```

After:
```json
"text": "# Hello World\n...",
"embed_source": null
```

Closes #26

## Test plan

- [x] Java file: embed_source contains tree-sitter summary
- [x] Markdown file: embed_source is null
- [x] Unknown extension: embed_source is null
- [x] concept-show displays reconstructed embed_source for null case
- [x] concept-show -s works for both null and non-null cases
- [x] All 21 existing tests pass