### PR TITLE
Improve README: prioritize concept-grep and local LLM setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,15 +62,9 @@ export PATH="$PWD/cli:$PATH"
 
 シェルの設定ファイル（`~/.bashrc`, `~/.zshrc` 等）に追記すると永続化できます。
 
-### OpenAI APIを使う場合
+### ローカルLLMを使う場合（LM Studio） — 推奨
 
-```bash
-export OPENAI_API_KEY="sk-..."
-```
-
-### ローカルLLMを使う場合（LM Studio）
-
-[LM Studio](https://lmstudio.ai/) を使えば、OpenAI APIの代わりにローカルの埋め込みモデルを利用できます。APIキーは不要です。
+[LM Studio](https://lmstudio.ai/) を使えば、ローカルの埋め込みモデルを無料で利用できます。APIキーは不要で、大量のファイルをインデックス化する際にコストがかかりません。
 
 1. LM Studioをインストールして起動
 2. 埋め込みモデルをダウンロード（下表参照）
@@ -97,17 +91,131 @@ export CONCEPT_EMBED_MODEL="granite-embedding-278m-multilingual"  # または Qw
 あとはCLIツールをそのまま使えます — 自動的にローカルモデルが使われます:
 
 ```bash
-concept-embed --name "My Concept" --text "埋め込みたいテキスト" -o output.concept
-```
+# ソースファイルをインデックス化
+concept-grep --index -r src/
 
-コマンドごとに指定することもできます:
-
-```bash
-concept-embed --api-base http://localhost:1234/v1 --model granite-embedding-278m-multilingual \
-  --name "My Concept" --text "埋め込みたいテキスト" -o output.concept
+# 意味でコードを検索
+concept-grep -r "ユーザー認証" src/
 ```
 
 ## CLI ツール
+
+### concept-grep
+
+セマンティック grep — ソースファイルを意味で検索します。`.concept/` ディレクトリの集中インデックス、またはソースファイルと同階層の `.concept` ファイルを使用します。
+
+```bash
+# まずソースファイルをインデックス化
+concept-grep --index -r src/
+
+# 意味で検索（出力はファイルパスのみ）
+concept-grep "ユーザー認証" src/*.java
+
+# 再帰検索
+concept-grep -r "決済処理" src/
+
+# スコア表示
+concept-grep -s "サーバーへのデータ送信" src/*.java
+
+# 上位20%を表示
+concept-grep -p 20 -r "データバリデーション" src/
+
+# 逆マッチ: 類似度が低いファイルを表示
+concept-grep -v "サーバーへのデータ送信" src/*.java
+
+# パイプと組み合わせ
+concept-grep -r "エラーハンドリング" src/ | xargs cat
+```
+
+インデックスの検索順序:
+
+1. `.concept/` ディレクトリ（例: `.concept/src/main.java.concept`）
+2. ソースファイルと同階層（例: `src/main.java.concept`）— フォールバック
+
+```text
+# 集中インデックス
+.concept/
+├── src/
+│   ├── main.java.concept
+│   └── client.java.concept
+src/
+├── main.java
+└── client.java
+
+# または同階層レイアウト
+src/
+├── main.java
+├── main.java.concept
+├── client.java
+└── client.java.concept
+```
+
+オプション:
+- `-r, --recursive` — ディレクトリを再帰的に検索（`.git/`, `.concept/`, `.venv/`, `node_modules/` はスキップ）
+- `-s, --score` — 類似度スコアを表示
+- `-g, --graph` — 類似度をバーグラフで表示
+- `-v, --invert-match` — 類似度が低いファイルを表示（逆マッチ、`grep -v` と同様）
+- `-n, --top` — 上位N件のみ表示（デフォルト: 全件）
+- `-p, --top-percent` — 上位N%を表示（デフォルト: 10）
+- `--index` — 指定したソースファイルの `.concept` ファイルを生成（対応言語では tree-sitter による要約を使用）。`.concept/` ディレクトリは `.git/` の隣に作成。変更のないファイル（SHA-256ハッシュ比較）はスキップ
+- `--force` — `.git` がなくてもカレントディレクトリに `.concept/` を強制作成
+- `--model` — 埋め込みモデル（デフォルト: `text-embedding-3-small`、環境変数 `CONCEPT_EMBED_MODEL`）
+- `--api-base` — OpenAI互換APIのベースURL（環境変数 `CONCEPT_API_BASE`）
+
+#### Tree-sitter 対応言語
+
+`concept-grep --index` や `concept-embed --source-file` でソースファイルをインデックス化する際、tree-sitter を使用して構造的な要約（クラス、関数、型シグネチャなど）を抽出し、より高品質な埋め込みを生成します。非対応のファイルは元のテキストをそのまま使用します。
+
+| 言語 | 拡張子 |
+|------|--------|
+| Java | `.java` |
+| Python | `.py` |
+| JavaScript | `.js`, `.mjs`, `.cjs`, `.jsx` |
+| TypeScript | `.ts`, `.tsx` |
+| Go | `.go` |
+| Rust | `.rs` |
+| C | `.c`, `.h` |
+| C++ | `.cpp`, `.cxx`, `.cc`, `.hpp`, `.hxx`, `.hh` |
+| C# | `.cs` |
+| Ruby | `.rb` |
+| PHP | `.php` |
+| Swift | `.swift` |
+| Kotlin | `.kt`, `.kts` |
+| Scala | `.scala` |
+| Haskell | `.hs` |
+| Elixir | `.ex`, `.exs` |
+| Lua | `.lua` |
+| Bash | `.sh`, `.bash` |
+| Objective-C | `.m` |
+| OCaml | `.ml`, `.mli` |
+| Zig | `.zig` |
+| HTML | `.html`, `.htm` |
+| CSS | `.css` |
+| JSON | `.json` |
+| YAML | `.yaml`, `.yml` |
+| TOML | `.toml` |
+
+### concept-search
+
+自然言語のクエリテキストで `.concept` ファイルをセマンティック検索します。デフォルト出力はファイルパスのみ（Unix フレンドリー）。
+
+```bash
+# .concept ファイルを検索
+concept-search "iOS Safari browser bug" concepts/*.concept
+
+# スコア表示
+concept-search -s "TypeScript型エラー" concepts/*.concept
+
+# 上位5件のみ表示
+concept-search -n 5 "hydration problem" concepts/*.concept
+```
+
+オプション:
+- `-s, --score` — 類似度スコアを表示
+- `-n, --top` — 上位N件のみ表示（デフォルト: 全件）
+- `--threshold` — 最低類似度スコア（デフォルト: 0.5）
+- `--model` — 埋め込みモデル（デフォルト: `text-embedding-3-small`、環境変数 `CONCEPT_EMBED_MODEL`）
+- `--api-base` — OpenAI互換APIのベースURL（環境変数 `CONCEPT_API_BASE`）
 
 ### concept-embed
 
@@ -168,124 +276,6 @@ package com.example.shop.model;
 - `--json` — 生JSONを出力
 
 `--json` で生のJSONボディを出力できます。
-
-### concept-search
-
-自然言語のクエリテキストで `.concept` ファイルをセマンティック検索します。デフォルト出力はファイルパスのみ（Unix フレンドリー）。
-
-```bash
-# .concept ファイルを検索
-concept-search "iOS Safari browser bug" concepts/*.concept
-
-# スコア表示
-concept-search -s "TypeScript型エラー" concepts/*.concept
-
-# 上位5件のみ表示
-concept-search -n 5 "hydration problem" concepts/*.concept
-```
-
-オプション:
-- `-s, --score` — 類似度スコアを表示
-- `-n, --top` — 上位N件のみ表示（デフォルト: 全件）
-- `--threshold` — 最低類似度スコア（デフォルト: 0.5）
-- `--model` — 埋め込みモデル（デフォルト: `text-embedding-3-small`、環境変数 `CONCEPT_EMBED_MODEL`）
-- `--api-base` — OpenAI互換APIのベースURL（環境変数 `CONCEPT_API_BASE`）
-
-### concept-grep
-
-セマンティック grep — ソースファイルを意味で検索します。`.concept/` ディレクトリの集中インデックス、またはソースファイルと同階層の `.concept` ファイルを使用します。
-
-```bash
-# まずソースファイルをインデックス化
-concept-grep --index -r src/
-
-# 意味で検索（出力はファイルパスのみ）
-concept-grep "ユーザー認証" src/*.java
-
-# 再帰検索
-concept-grep -r "決済処理" src/
-
-# スコア表示
-concept-grep -s "サーバーへのデータ送信" src/*.java
-
-# 上位20%を表示
-concept-grep -p 20 -r "データバリデーション" src/
-
-# 逆マッチ: 類似度が低いファイルを表示
-concept-grep -v "サーバーへのデータ送信" src/*.java
-
-# パイプと組み合わせ
-concept-grep -r "エラーハンドリング" src/ | xargs cat
-```
-
-インデックスの検索順序:
-
-1. `.concept/` ディレクトリ（例: `.concept/src/main.java.concept`）
-2. ソースファイルと同階層（例: `src/main.java.concept`）— フォールバック
-
-```text
-# 集中インデックス
-.concept/
-├── src/
-│   ├── main.java.concept
-│   └── client.java.concept
-src/
-├── main.java
-└── client.java
-
-# または同階層レイアウト
-src/
-├── main.java
-├── main.java.concept
-├── client.java
-└── client.java.concept
-```
-
-オプション:
-- `-r, --recursive` — ディレクトリを再帰的に検索（`.git/`, `.concept/`, `.venv/`, `node_modules/` はスキップ）
-- `-s, --score` — 類似度スコアを表示
-- `-g, --graph` — 類似度をバーグラフで表示
-- `-v, --invert-match` — 類似度が低いファイルを表示（逆マッチ、`grep -v` と同様）
-- `-n, --top` — 上位N件のみ表示（デフォルト: 全件）
-- `-p, --top-percent` — 上位N%を表示（デフォルト: 10）
-- `--threshold` — 最低類似度スコア（デフォルト: 0.5）
-- `--index` — 指定したソースファイルの `.concept` ファイルを生成（対応言語では tree-sitter による要約を使用）。`.concept/` ディレクトリは `.git/` の隣に作成。変更のないファイル（SHA-256ハッシュ比較）はスキップ
-- `--force` — `.git` がなくてもカレントディレクトリに `.concept/` を強制作成
-- `--model` — 埋め込みモデル（デフォルト: `text-embedding-3-small`、環境変数 `CONCEPT_EMBED_MODEL`）
-- `--api-base` — OpenAI互換APIのベースURL（環境変数 `CONCEPT_API_BASE`）
-
-#### Tree-sitter 対応言語
-
-`concept-grep --index` や `concept-embed --source-file` でソースファイルをインデックス化する際、tree-sitter を使用して構造的な要約（クラス、関数、型シグネチャなど）を抽出し、より高品質な埋め込みを生成します。非対応のファイルは元のテキストをそのまま使用します。
-
-| 言語 | 拡張子 |
-|------|--------|
-| Java | `.java` |
-| Python | `.py` |
-| JavaScript | `.js`, `.mjs`, `.cjs`, `.jsx` |
-| TypeScript | `.ts`, `.tsx` |
-| Go | `.go` |
-| Rust | `.rs` |
-| C | `.c`, `.h` |
-| C++ | `.cpp`, `.cxx`, `.cc`, `.hpp`, `.hxx`, `.hh` |
-| C# | `.cs` |
-| Ruby | `.rb` |
-| PHP | `.php` |
-| Swift | `.swift` |
-| Kotlin | `.kt`, `.kts` |
-| Scala | `.scala` |
-| Haskell | `.hs` |
-| Elixir | `.ex`, `.exs` |
-| Lua | `.lua` |
-| Bash | `.sh`, `.bash` |
-| Objective-C | `.m` |
-| OCaml | `.ml`, `.mli` |
-| Zig | `.zig` |
-| HTML | `.html`, `.htm` |
-| CSS | `.css` |
-| JSON | `.json` |
-| YAML | `.yaml`, `.yml` |
-| TOML | `.toml` |
 
 ### concept-sim
 
@@ -536,6 +526,14 @@ concept-file/
     │   └── concepts/        — 生成された .concept ファイル
     └── vuejs-issues/
         └── concepts/        — vuejs/core の GitHub issue
+```
+
+## OpenAI APIを使う場合
+
+ローカルLLMの代わりにOpenAI APIを使うこともできます:
+
+```bash
+export OPENAI_API_KEY="sk-..."
 ```
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -64,15 +64,9 @@ export PATH="$PWD/cli:$PATH"
 
 You can add this to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) to make it permanent.
 
-### Using OpenAI API
+### Using a Local LLM (LM Studio) — Recommended
 
-```bash
-export OPENAI_API_KEY="sk-..."
-```
-
-### Using a Local LLM (LM Studio)
-
-You can use a local embedding model via [LM Studio](https://lmstudio.ai/) instead of the OpenAI API. No API key required.
+You can use a local embedding model via [LM Studio](https://lmstudio.ai/). No API key required, and embedding is free — ideal for indexing large codebases.
 
 1. Install and launch LM Studio
 2. Download an embedding model (see table below)
@@ -99,99 +93,14 @@ export CONCEPT_EMBED_MODEL="granite-embedding-278m-multilingual"  # or Qwen3-Emb
 Then use the CLI tools as usual — they will automatically use the local model:
 
 ```bash
-concept-embed --name "My Concept" --text "Some text" -o output.concept
-```
+# Index source files
+concept-grep --index -r src/
 
-You can also specify these per-command:
-
-```bash
-concept-embed --api-base http://localhost:1234/v1 --model granite-embedding-278m-multilingual \
-  --name "My Concept" --text "Some text" -o output.concept
+# Search by meaning
+concept-grep -r "user authentication" src/
 ```
 
 ## CLI Tools
-
-### concept-embed
-
-Generate a `.concept` file from text with an embedding vector.
-
-```bash
-# From a command-line argument
-cli/concept-embed --name "My Concept" --text "Some text to embed" -o output.concept
-
-# From stdin
-echo "Some text to embed" | cli/concept-embed --name "My Concept" -o output.concept
-
-# From a source file
-cat src/User.java | cli/concept-embed --name "User" -o src/User.java.concept
-```
-
-Options:
-- `--name` — Concept name (required)
-- `--text` — Text content (reads stdin if omitted)
-- `-o, --output` — Output file path (required)
-- `--model` — Embedding model (default: `text-embedding-3-small`)
-- `--language` — BCP 47 language tag (e.g. `en`, `ja`)
-- `--keywords` — Keywords / tags
-- `--source-file` — Source file path (enables tree-sitter summarization for supported languages)
-- `--source-url` — Source URL for provenance
-- `--no-embed` — Skip embedding generation
-
-### concept-show
-
-Display the contents of a `.concept` file in human-readable form.
-
-```bash
-cli/concept-show output.concept
-```
-
-```
-Concept:  User
-Version:  1.0
-Created:  2026-03-14T13:46:11.223280+00:00
-Embedding: 1536-dim (text-embedding-3-small)
-Pipeline: embed
-
---- Embed Source ---
-User.java
-package com.example.shop.model
-class User
-  field email: String
-  method verifyPassword(rawPassword: String): boolean
-  ...
-
---- Text ---
-package com.example.shop.model;
-...
-```
-
-Options:
-- `-s, --summary` — Show only embed_source summary (omit full text)
-- `--json` — Output raw JSON
-
-Use `--json` to output the raw JSON body.
-
-### concept-search
-
-Semantic search over `.concept` files using a natural language query. Output is file paths only by default (Unix-friendly).
-
-```bash
-# Search .concept files
-concept-search "iOS Safari browser bug" concepts/*.concept
-
-# Show scores
-concept-search -s "TypeScript type error" concepts/*.concept
-
-# Top 5 results only
-concept-search -n 5 "hydration problem" concepts/*.concept
-```
-
-Options:
-- `-s, --score` — Show similarity scores
-- `-n, --top` — Show only top N results (default: all)
-- `--threshold` — Minimum similarity score (default: 0.5)
-- `--model` — Embedding model (default: `text-embedding-3-small`, env: `CONCEPT_EMBED_MODEL`)
-- `--api-base` — OpenAI-compatible API base URL (env: `CONCEPT_API_BASE`)
 
 ### concept-grep
 
@@ -287,6 +196,88 @@ When indexing source files with `concept-grep --index` or `concept-embed --sourc
 | JSON | `.json` |
 | YAML | `.yaml`, `.yml` |
 | TOML | `.toml` |
+
+### concept-search
+
+Semantic search over `.concept` files using a natural language query. Output is file paths only by default (Unix-friendly).
+
+```bash
+# Search .concept files
+concept-search "iOS Safari browser bug" concepts/*.concept
+
+# Show scores
+concept-search -s "TypeScript type error" concepts/*.concept
+
+# Top 5 results only
+concept-search -n 5 "hydration problem" concepts/*.concept
+```
+
+Options:
+- `-s, --score` — Show similarity scores
+- `-n, --top` — Show only top N results (default: all)
+- `--threshold` — Minimum similarity score (default: 0.5)
+- `--model` — Embedding model (default: `text-embedding-3-small`, env: `CONCEPT_EMBED_MODEL`)
+- `--api-base` — OpenAI-compatible API base URL (env: `CONCEPT_API_BASE`)
+
+### concept-embed
+
+Generate a `.concept` file from text with an embedding vector.
+
+```bash
+# From a command-line argument
+cli/concept-embed --name "My Concept" --text "Some text to embed" -o output.concept
+
+# From stdin
+echo "Some text to embed" | cli/concept-embed --name "My Concept" -o output.concept
+
+# From a source file
+cat src/User.java | cli/concept-embed --name "User" -o src/User.java.concept
+```
+
+Options:
+- `--name` — Concept name (required)
+- `--text` — Text content (reads stdin if omitted)
+- `-o, --output` — Output file path (required)
+- `--model` — Embedding model (default: `text-embedding-3-small`)
+- `--language` — BCP 47 language tag (e.g. `en`, `ja`)
+- `--keywords` — Keywords / tags
+- `--source-file` — Source file path (enables tree-sitter summarization for supported languages)
+- `--source-url` — Source URL for provenance
+- `--no-embed` — Skip embedding generation
+
+### concept-show
+
+Display the contents of a `.concept` file in human-readable form.
+
+```bash
+cli/concept-show output.concept
+```
+
+```
+Concept:  User
+Version:  1.0
+Created:  2026-03-14T13:46:11.223280+00:00
+Embedding: 1536-dim (text-embedding-3-small)
+Pipeline: embed
+
+--- Embed Source ---
+User.java
+package com.example.shop.model
+class User
+  field email: String
+  method verifyPassword(rawPassword: String): boolean
+  ...
+
+--- Text ---
+package com.example.shop.model;
+...
+```
+
+Options:
+- `-s, --summary` — Show only embed_source summary (omit full text)
+- `--json` — Output raw JSON
+
+Use `--json` to output the raw JSON body.
 
 ### concept-sim
 
@@ -514,6 +505,14 @@ concept-file/
     │   └── concepts/        — Generated .concept files
     └── vuejs-issues/
         └── concepts/        — vuejs/core GitHub issues
+```
+
+## Using OpenAI API
+
+You can also use the OpenAI API instead of a local LLM:
+
+```bash
+export OPENAI_API_KEY="sk-..."
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- Reorder Setup section: local LLM (LM Studio) first as recommended default, OpenAI API moved to end of document
- Reorder CLI Tools section: concept-grep > concept-search > concept-embed > concept-show > concept-sim > concept-plot
- Show `concept-grep --index` + `concept-grep` workflow as the first example after LM Studio setup
- Remove stale `--threshold` option from concept-grep documentation (option no longer exists in CLI)
- Applied consistently to both README.md and README.ja.md

Closes #29

## Test plan
- [x] Verify all links and code examples render correctly in both READMEs
- [x] Confirm CLI tool section order matches issue requirements
- [x] Confirm LM Studio setup appears before OpenAI API

🤖 Generated with [Claude Code](https://claude.com/claude-code)