### PR TITLE
Enforce embedding model consistency in concept-grep

### DIFF
--- a/cli/concept-grep
+++ b/cli/concept-grep
@@ -201,10 +201,13 @@ def main():
                 try:
                     existing = read_existing(str(concept_path))
                     existing_hash = existing.get("provenance", {}).get("source_hash")
-                    if existing_hash == current_hash:
+                    existing_model = existing.get("embedding", {}).get("model")
+                    if existing_hash == current_hash and existing_model == args.model:
                         skipped += 1
                         print(f"Skipped (unchanged): {sf}", file=sys.stderr)
                         continue
+                    if existing_hash == current_hash and existing_model != args.model:
+                        print(f"Re-indexing (model changed: {existing_model} -> {args.model}): {sf}", file=sys.stderr)
                 except (ValueError, FileNotFoundError):
                     pass
             concept_path.parent.mkdir(parents=True, exist_ok=True)
@@ -271,6 +274,13 @@ def main():
                 continue
         try:
             data = read_concept(str(concept_path))
+            file_model = data.get("embedding", {}).get("model")
+            if file_model and file_model != args.model:
+                print(f"Error: model mismatch: {concept_path} was embedded with '{file_model}' "
+                      f"but current model is '{args.model}'. "
+                      f"Re-run 'concept-grep --index' to re-embed.",
+                      file=sys.stderr)
+                sys.exit(1)
             target_vec = data.get("embedding", {}).get("vector")
             if not target_vec:
                 continue


### PR DESCRIPTION
## Summary

- **`concept-grep --index`**: Re-index `.concept` files when the embedding model (`CONCEPT_EMBED_MODEL` / `--model`) has changed, even if the source file hash is unchanged
- **`concept-grep` (search mode)**: Abort with a non-zero exit code when a `.concept` file was embedded with a different model than the current one, preventing meaningless similarity comparisons

Closes #33

## Test plan

- [x] Run `concept-grep --index -r .` with one model, then change `CONCEPT_EMBED_MODEL` and re-run — verify files are re-indexed with "Re-indexing (model changed: ...)" message
- [x] Run `concept-grep "query" -r .` with a different `CONCEPT_EMBED_MODEL` than the indexed model — verify error message and non-zero exit code
- [x] Run normal workflow (same model) — verify no regressions in skip/search behavior